### PR TITLE
Switch debug() to stdout instead of stderr

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+process.env.DEBUG_FD = 1; // debug() echoes to stdout instead of stderr
+
 const express = require('express');
 const bodyParser = require('body-parser');
 const compression = require('compression');

--- a/push_sender.js
+++ b/push_sender.js
@@ -1,3 +1,5 @@
+process.env.DEBUG_FD = 1; // debug() echoes to stdout instead of stderr
+
 const debug = require('debug')('calendar-server:business/push_sender');
 const config = require('./config');
 const mq = require('zmq').socket('pull');


### PR DESCRIPTION
Output on stderr is by design, see https://github.com/visionmedia/debug/issues/120. One easy way to set this value globally is by [defining DEBUG_FD](https://github.com/visionmedia/debug/blob/92eaeede1af418dad7604febde25be73108e6c26/node.js#L35). I'm not sure what's the best place to put it. I was thinking of `package.json` or something like `config/config.json`, but the simplest for now seems to just define it in the main entry points. 

What do you think @julienw ?
