### PR TITLE
We can now use `myself` to represent the currently logged-in id every…

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,14 +34,13 @@ app.use(
     .unless({ path: [ { url: `${API_ROOT}/users`, methods: 'POST' } ] })
 );
 
+// rewrite "myself" with the logged in user id
+app.use(require('./routes/myself'));
+
 app.use(`${API_ROOT}/reminders`, require('./routes/reminders'));
 app.use(`${API_ROOT}/subscriptions`, require('./routes/subscriptions'));
 app.use(`${API_ROOT}/users`, require('./routes/users'));
 app.use(`${API_ROOT}/groups`, require('./routes/groups'));
-
-app.get('/', (req, res) => {
-  res.send('You may want to use the API instead.');
-});
 
 app.use((err, req, res, next) => {
   if (res.headersSent) {

--- a/dao/reminders.js
+++ b/dao/reminders.js
@@ -135,8 +135,8 @@ module.exports = {
       .then(db => db.all(statement, ...statementArgs));
   },
 
-  create(userId, reminder) {
-    debug('create(userId=%s, reminder=%o)', userId, reminder);
+  create(reminder) {
+    debug('create(reminder=%o)', reminder);
 
     checkIsArray(reminder, 'recipients', 1);
     checkPropertyType(reminder, 'action', 'string');

--- a/routes/myself.js
+++ b/routes/myself.js
@@ -1,0 +1,14 @@
+const debug = require('debug')('calendar-server:routes/myself');
+const express = require('express');
+const router = express.Router();
+
+const myselfRe = /\bmyself\b/g;
+router.use((req, res, next) => {
+  if (req.user && myselfRe.test(req.url)) {
+    debug(`Replacing 'myself' with ${req.user.id}`);
+    req.url = req.url.replace(myselfRe, `/${req.user.id}`);
+  }
+  next();
+});
+
+module.exports = router;

--- a/routes/reminders.js
+++ b/routes/reminders.js
@@ -28,8 +28,13 @@ router.get('/', (req, res, next) => {
 });
 
 router.post('/', (req, res, next) => {
-  const userId = req.user.id;
-  reminders.create(userId, req.body).then((id) => {
+  const newReminder = req.body;
+  newReminder.recipients.forEach(recipient => {
+    if (recipient.userId === 'myself') {
+      recipient.userId = +req.user.id;
+    }
+  });
+  reminders.create(newReminder).then((id) => {
     debug('Reminder #%s has been created in database', id);
 
     return reminders.show(id);

--- a/test/api_users_test.js
+++ b/test/api_users_test.js
@@ -43,15 +43,23 @@ describe('/users', function() {
     user.id = yield api.createUser(user);
     yield api.login(user.email, user.password);
 
-    const res = yield chakram.get(
+    let res = yield chakram.get(
       `${config.apiRoot}/users/${user.id}`
     );
 
-    expect(res).status(200);
-    expect(res.body).deep.equal({
+    const expectedUser = {
       id: user.id,
       forename: user.forename,
-    });
+    };
+    expect(res).status(200);
+    expect(res.body).deep.equal(expectedUser);
+
+    // We can also access it using the word `myself`
+    res = yield chakram.get(
+      `${config.apiRoot}/users/myself`
+    );
+    expect(res).status(200);
+    expect(res.body).deep.equal(expectedUser);
   });
 
   it('Other users within the same group can retrieve a user', function*() {
@@ -145,6 +153,23 @@ describe('/users', function() {
 
     res = yield chakram.get(
       `${config.apiRoot}/users/${user1.id}/relations`
+    );
+    expect(res).status(200);
+    expect(res.body).deep.equal(
+      [{ id: 2, forename: 'Johan', email: 'johan@johan.com' }]
+    );
+
+    // user1 is the logged-in user, so trying with "myself" a swell
+    res = yield chakram.get(
+      `${config.apiRoot}/users/myself/groups`
+    );
+    expect(res).status(200);
+    expect(res.body).deep.equal(
+      [{ id: 1, name: 'CD_Staff' }]
+    );
+
+    res = yield chakram.get(
+      `${config.apiRoot}/users/myself/relations`
     );
     expect(res).status(200);
     expect(res.body).deep.equal(

--- a/test/dao_test.js
+++ b/test/dao_test.js
@@ -45,10 +45,10 @@ describe('dao', () => {
       });
     });
 
-    describe('create(groupId, reminder)', function() {
+    describe('create(reminder)', function() {
       it('should create a new reminder in the database and' +
         ' associate with users', function*() {
-        const result = yield reminders.create(1, {
+        const result = yield reminders.create({
           recipients: [ { userId: 1 }, { userId: 2 }],
           action: 'pick up from school',
           due: 1470839865000


### PR DESCRIPTION
…where a user id is expected (Closes #48)
